### PR TITLE
[#49] Shift OCR process to use TIFF images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -90,8 +90,8 @@ pytest==8.3.4
 python-dateutil==2.9.0.post0
 python-json-logger==3.2.1
 pytz==2025.1
-pywin32==308
-pywinpty==2.0.15
+pywin32==308;sys_platform == 'win32'
+pywinpty==2.0.15;sys_platform == 'win32'
 PyYAML==6.0.2
 pyzmq==26.2.1
 referencing==0.36.2


### PR DESCRIPTION
Updated the requirements.txt file to have the two win32 libraries only be installed when installing on a Windows OS.

Updated the `extract_text_from_pdf` method to utilize TIFF images. Doing so allowed us to get all text across all pages of the test-ocr.pdf file that we've been doing our manual tests on. Previously, we were only getting the first page of content.

Closes #49 