### PR TITLE
[#21] Create test to verify OCR is parsing the test entry correctly

### DIFF
--- a/.github/workflows/clean-build-test.yml
+++ b/.github/workflows/clean-build-test.yml
@@ -41,10 +41,14 @@ jobs:
         run: chmod +x build.sh
 
       - name: Run build script
-        run: ./build.sh
+        run: |
+            source .env/bin/activate
+            ./build.sh
 
       - name: Make test script executable
         run: chmod +x test.sh
 
       - name: Run test script
-        run: ./test.sh
+        run: |
+            source .env/bin/activate
+            ./test.sh

--- a/.github/workflows/clean-build-test.yml
+++ b/.github/workflows/clean-build-test.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt update -y
           sudo apt install -y build-essential libssl-dev zlib1g-dev \
           libbz2-dev libreadline-dev libsqlite3-dev curl git \
-          libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+          libncursesw5-dev xz-utils tk-dev python3.12-tk libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
           tesseract-ocr libtesseract-dev poppler-utils
           python -m venv .env
           source .env/bin/activate

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Assuming machine is running Ubuntu and Python 3.12 is already installed on your 
 ```bash
 sudo apt update -y; sudo apt install -y build-essential libssl-dev zlib1g-dev \
 libbz2-dev libreadline-dev libsqlite3-dev curl git \
-libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+libncursesw5-dev xz-utils tk-dev python3.12-tk libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
 tesseract-ocr libtesseract-dev poppler-utils
 
 python -m venv .env

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-from controller import AppController
+from src.controller import AppController
 
 def main():
     app = AppController()

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,6 +1,6 @@
-from ocr import OCRProcessor
-from gui import GUI
-from states import AppState
+from src.ocr import OCRProcessor
+from src.gui import GUI
+from src.states import AppState
 
 class AppController:
     def __init__(self):

--- a/src/gui.py
+++ b/src/gui.py
@@ -7,7 +7,7 @@ except ImportError:
     from tkinter import *
 
 from tkinterdnd2 import TkinterDnD, DND_FILES
-from states import AppState
+from src.states import AppState
 
 file_pic_base_64 = ('iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAMAAABg3Am1AAAAk1BMVEVHcEzJz9j/Vi/'
                     'jMQbo6+7FytL/VS/ovrbq6+/e4Obs9fvhZUfbLwnYy835UizR1N3/VjDM0tn9XzzHzdb'

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -2,7 +2,7 @@ import os
 import csv
 from tkinter import messagebox
 import pytesseract
-from config import set_tesseract_path
+from src.config import set_tesseract_path
 from pdf2image import convert_from_path
 from PIL import Image, ImageSequence
 

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [ -d "test" ]; then
+if [ -d "tests" ]; then
   echo "Running tests..."
-  cd test || exit 3
+  cd tests || exit 3
   pytest
   exit $?
 else
-  echo "test dir doesn't exist. Nothing to do."
+  echo "tests dir doesn't exist. Nothing to do."
 
   exit 4
 fi

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,22 @@
+import os
+
+from src.ocr import OCRProcessor
+
+
+def test_sample():
+    text, csv_path = OCRProcessor.extract_text_from_pdf("../resources/test-ocr.pdf")
+    assert text is not None, "Returned text is None"
+    assert csv_path is not None, "Returned CSV path is None"
+
+    assert text.strip(), "Returned text is empty after trimming"
+
+    checks = [
+        "This file contains some words.",
+        "This file also contains text.",
+        "This second part of the text is in Page 2"
+    ]
+    for check_num, check in enumerate(checks):
+        assert check in text, f"Sentence {check_num + 1} is missing from the parsed text"
+
+    assert os.path.exists(csv_path), f"CSV path {csv_path} does not exist"
+    os.remove(csv_path)


### PR DESCRIPTION
Implemented a pytest script & function to fit our testing framework. Test passes.

Had to update the existing scripts in `src` to specify the local imports. For example, instead of `from config import set_tesseract_path` it's now `from src.config import set_tesseract_path`. This needs to be done so that when the components are imported in the tests there isn't an import error. Without specifying the `src` part of the import, the interpreter doesn't know where to look.

Closes #21 