### PR TITLE
[#56] Implement tests for parsed pdf cleaning

### DIFF
--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,11 +1,12 @@
-import os
 import csv
+import os
 import time
-from tkinter import messagebox
+
 import pytesseract
-from src.config import set_tesseract_path
-from pdf2image import convert_from_path
 from PIL import Image, ImageSequence
+from pdf2image import convert_from_path
+
+from src.config import set_tesseract_path
 
 
 class OCRProcessor:
@@ -119,6 +120,20 @@ class OCRProcessor:
         except Exception as e:
             self.master.gui.handle_error("File Handling Error", f"Unable to open file: {pdf_path}")
             return None
+
+
+    def clean_text(self, extracted_text):
+        """Cleans text into the expected format.
+
+        Returns the cleaned text in CSV-ready format (DataFrame, list of rows, etc.)"""
+        # TODO: Will be implemented in a Sprint after Sprint 2.
+        try:
+            return extracted_text
+        except Exception as e:
+            error_message = f"Failed to save CSV file: {str(e)}"
+            self.master.gui.handle_error("Cleaning Error", error_message)
+            return extracted_text
+
 
     def save_csv(self, csv_path, extracted_text):
         try:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,0 +1,70 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+import pandas as pd
+
+from src.ocr import OCRProcessor
+
+# Mock the master object (assuming it has a 'gui' attribute with a 'handle_error' method)
+mock_master = MagicMock()
+mock_master.gui.handle_error = MagicMock()
+
+@pytest.mark.parametrize("pdf_path", [
+    "../resources/test-entries/pdfs/1975-a1_1-2.pdf",
+    "../resources/test-entries/pdfs/1977-c184_1-5.pdf",
+    "../resources/test-entries/pdfs/1979-a33_1-1.pdf",
+    "../resources/test-entries/pdfs/1982-a15-16_2-1.pdf",
+    "../resources/test-entries/pdfs/1983-a11-12_2-2.pdf",
+    "../resources/test-entries/pdfs/1985-j34-38_5-1.pdf",
+    "../resources/test-entries/pdfs/1986-p255-257_5-3-1-1.pdf",
+    "../resources/test-entries/pdfs/1987-page468.pdf",
+    "../resources/test-entries/pdfs/1988-page555.pdf",
+    "../resources/test-entries/pdfs/1989-d60_1-2.pdf",
+    "../resources/test-entries/pdfs/1990-a39_1-5.pdf",
+    "../resources/test-entries/pdfs/1991-page314.pdf",
+    "../resources/test-entries/pdfs/1992-a361_1-7.pdf",
+    "../resources/test-entries/pdfs/1993-page566.pdf",
+    "../resources/test-entries/pdfs/1994-G-g1-see.pdf",
+    "../resources/test-entries/pdfs/1995-3-sees.pdf",
+    "../resources/test-entries/pdfs/1996-page-2_sees-g247.pdf",
+    "../resources/test-entries/pdfs/1997-large-corp.pdf",
+    "../resources/test-entries/pdfs/1998-page305.pdf",
+])
+@pytest.mark.slow
+def test_parsing(pdf_path):
+    # Instantiate OCRProcessor with the mock master
+    ocr_processor = OCRProcessor(mock_master)
+
+    # Call the extract_text_from_pdf method
+    csv_path, extracted_text = ocr_processor.extract_text_from_pdf(pdf_path)
+
+    # Ensure the extracted text is not None and not empty
+    assert extracted_text is not None, "Extracted text is None"
+    assert extracted_text.strip(), "Extracted text is empty after trimming"
+
+    # Call the clean method
+    cleaned_text = ocr_processor.clean_text(extracted_text)
+
+    # Ensure the cleaned text is not None and not empty
+    assert cleaned_text is not None, "Cleaned text is None"
+    assert cleaned_text.strip(), "Cleaned text is empty after trimming"
+
+    # Save the cleaned text to a CSV file
+    saved_csv_path = ocr_processor.save_csv(csv_path, cleaned_text)
+
+    # Ensure the CSV file was saved successfully
+    assert saved_csv_path is not None, "Failed to save CSV file"
+
+    # Check that the output CSV and the expected CSV are equivalent
+    expected_csv_path = pdf_path.replace("pdfs", "csvs").replace(".pdf", ".csv")
+    expected = pd.read_csv(expected_csv_path)
+    actual = pd.read_csv(saved_csv_path)
+
+    # Clean up
+    if os.path.exists(saved_csv_path):
+        os.remove(saved_csv_path)
+
+    assert expected.equals(actual), "Cleaned text is not the same as the expected text"
+    del expected
+    del actual

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
 from src.ocr import OCRProcessor
 
 # Mock the master object (assuming it has a 'gui' attribute with a 'handle_error' method)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,11 +1,21 @@
 import os
+from unittest.mock import MagicMock
+
+import pytest
 
 from src.ocr import OCRProcessor
 
+# Mock the master object (assuming it has a 'gui' attribute with a 'handle_error' method)
+mock_master = MagicMock()
+mock_master.gui.handle_error = MagicMock()
 
+
+@pytest.mark.quick
 def test_sample():
-    csv_path, extracted_text = OCRProcessor.extract_text_from_pdf("../resources/test-ocr.pdf")
-    OCRProcessor.save_csv(csv_path, extracted_text)
+    ocr_processor = OCRProcessor(mock_master)
+    csv_path, extracted_text = ocr_processor.extract_text_from_pdf(pdf_path="../resources/test-ocr.pdf")
+    ocr_processor.save_csv(csv_path, extracted_text)
+
     assert extracted_text is not None, "Returned text is None"
     assert csv_path is not None, "Returned CSV path is None"
 


### PR DESCRIPTION
Implemented a placeholder clean function in the `OCRProcessor` class, fixed the sample test, small formatting changes, and implemented cleaning tests.

Currently all cleaning tests fail as we don't have any cleaning functionality, i.e., this is expected.

Closes #56 
