### PR TITLE
[#76] Implement threading for pdf parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ ipywidgets==8.1.5
 isoduration==20.11.0
 isort==6.0.0
 jedi==0.19.2
-Jinja2==3.1.5
+Jinja2==3.1.6
 json5==0.10.0
 jsonpointer==3.0.0
 jsonschema==4.23.0


### PR DESCRIPTION
Utilized multiprocessing to spawn a new process for each PDF. In our case, threading would cause us to butt heads with the global interpreter lock (GIL) problem, leaving us with an overly complex single-threaded performant piece of software. Utilizing multiprocessing instead of threading allows us to avoid that problem and get concurrency.

Closes #76 